### PR TITLE
Add notebook for Thomas solver overlay comparison

### DIFF
--- a/thomas_solver_test/ThomasSolverTest.ipynb
+++ b/thomas_solver_test/ThomasSolverTest.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a2de9176",
+   "metadata": {},
+   "source": [
+    "# Thomas Solver Overlay Test\n",
+    "\n",
+    "This notebook compares the FPGA implementation of a tridiagonal matrix solver against a NumPy implementation. It measures the execution time of each approach and checks that both produce the same result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34f591a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynq import Overlay, allocate\n",
+    "import numpy as np\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ee31f3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load overlay and inspect available IP blocks\n",
+    "overlay = Overlay('custom_tomas_solver_v1.bit')\n",
+    "print(overlay.ip_dict)\n",
+    "# Replace 'thomas_solver_0' with the actual IP name from the printed dictionary if different\n",
+    "solver_ip = overlay.thomas_solver_0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd0c3e1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N = 64\n",
+    "# Constants describing the tridiagonal matrix\n",
+    "dp = np.complex64(4+0j)\n",
+    "dp1 = np.complex64(3+0j)\n",
+    "dp2 = np.complex64(3+0j)\n",
+    "off = np.complex64(1+0j)\n",
+    "\n",
+    "# Allocate buffers accessible to the FPGA\n",
+    "a_b = allocate(shape=(N,), dtype=np.complex64)\n",
+    "a_x = allocate(shape=(N,), dtype=np.complex64)\n",
+    "\n",
+    "# Random right-hand side vector\n",
+    "b_np = (np.random.rand(N) + 1j*np.random.rand(N)).astype(np.complex64)\n",
+    "a_b[:] = b_np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18300b0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def thomas_solver_numpy(dp, dp1, dp2, off, b):\n",
+    "    N = b.shape[0]\n",
+    "    c_prime = np.empty(N, dtype=np.complex64)\n",
+    "    d_prime = np.empty(N, dtype=np.complex64)\n",
+    "    inv = 1.0/np.complex64(dp1)\n",
+    "    c_prime[0] = off * inv\n",
+    "    d_prime[0] = b[0] * inv\n",
+    "    for i in range(1, N-1):\n",
+    "        denom = dp - off * c_prime[i-1]\n",
+    "        inv = 1.0/denom\n",
+    "        c_prime[i] = off * inv\n",
+    "        d_prime[i] = (b[i] - off * d_prime[i-1]) * inv\n",
+    "    denom = dp2 - off * c_prime[N-2]\n",
+    "    d_prime[N-1] = (b[N-1] - off * d_prime[N-2]) / denom\n",
+    "    x = np.empty(N, dtype=np.complex64)\n",
+    "    x[-1] = d_prime[-1]\n",
+    "    for i in range(N-2, -1, -1):\n",
+    "        x[i] = d_prime[i] - c_prime[i] * x[i+1]\n",
+    "    return x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09878e2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# CPU reference implementation\n",
+    "t0 = time.time()\n",
+    "x_ref = thomas_solver_numpy(dp, dp1, dp2, off, b_np)\n",
+    "cpu_time = time.time() - t0\n",
+    "print(f'CPU time: {cpu_time*1e3:.3f} ms')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a555d194",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configure solver IP\n",
+    "a_rm = solver_ip.register_map\n",
+    "a_rm.dp_r = float(np.real(dp))\n",
+    "a_rm.dp_i = float(np.imag(dp))\n",
+    "a_rm.dp1_r = float(np.real(dp1))\n",
+    "a_rm.dp1_i = float(np.imag(dp1))\n",
+    "a_rm.dp2_r = float(np.real(dp2))\n",
+    "a_rm.dp2_i = float(np.imag(dp2))\n",
+    "a_rm.off_r = float(np.real(off))\n",
+    "a_rm.off_i = float(np.imag(off))\n",
+    "a_rm.b = a_b.physical_address\n",
+    "a_rm.x = a_x.physical_address\n",
+    "\n",
+    "# Run hardware solver\n",
+    "t0 = time.time()\n",
+    "a_rm.CTRL.AP_START = 1\n",
+    "while a_rm.CTRL.AP_DONE == 0:\n",
+    "    a_rm = solver_ip.register_map\n",
+    "hw_time = time.time() - t0\n",
+    "print(f'Hardware time: {hw_time*1e3:.3f} ms')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "862cea00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare results\n",
+    "x_hw = np.array(a_x)\n",
+    "print('Results match:', np.allclose(x_ref, x_hw, atol=1e-6))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bdc5698",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay.free()\n",
+    "a_b.free()\n",
+    "a_x.free()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add Jupyter notebook exercising the Thomas solver overlay on the Kria board
- Compare FPGA solver results and runtime against a NumPy reference implementation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924f4199108332924129892a713adf