### PR TITLE
Improve solver test output clarity and timing

### DIFF
--- a/thomas_solver_test/ThomasSolverTest.ipynb
+++ b/thomas_solver_test/ThomasSolverTest.ipynb
@@ -19,7 +19,12 @@
    "source": [
     "from pynq import Overlay, allocate\n",
     "import numpy as np\n",
-    "import time"
+    "import time\n",
+    "\n",
+    "np.set_printoptions(precision=4, suppress=True)\n",
+    "\n",
+    "def pretty_print(name, vec):\n",
+    "    print(f\"{name} =\\n{np.array2string(vec, precision=4, suppress_small=True)}\")\n"
    ]
   },
   {
@@ -31,9 +36,9 @@
    "source": [
     "# Load overlay and inspect available IP blocks\n",
     "overlay = Overlay('custom_tomas_solver_v1.bit')\n",
-    "print(overlay.ip_dict)\n",
+    "print('Available IP blocks:', list(overlay.ip_dict.keys()))\n",
     "# Replace 'thomas_solver_0' with the actual IP name from the printed dictionary if different\n",
-    "solver_ip = overlay.thomas_solver_0"
+    "solver_ip = overlay.thomas_solver_0\n"
    ]
   },
   {
@@ -56,7 +61,8 @@
     "\n",
     "# Random right-hand side vector\n",
     "b_np = (np.random.rand(N) + 1j*np.random.rand(N)).astype(np.complex64)\n",
-    "a_b[:] = b_np"
+    "a_b[:] = b_np\n",
+    "pretty_print('Input vector b', b_np)\n"
    ]
   },
   {
@@ -98,7 +104,7 @@
     "t0 = time.time()\n",
     "x_ref = thomas_solver_numpy(dp, dp1, dp2, off, b_np)\n",
     "cpu_time = time.time() - t0\n",
-    "print(f'CPU time: {cpu_time*1e3:.3f} ms')"
+    "print(f'CPU time: {cpu_time*1e3:.3f} ms')\n"
    ]
   },
   {
@@ -127,7 +133,9 @@
     "while a_rm.CTRL.AP_DONE == 0:\n",
     "    a_rm = solver_ip.register_map\n",
     "hw_time = time.time() - t0\n",
-    "print(f'Hardware time: {hw_time*1e3:.3f} ms')"
+    "print(f'Hardware time: {hw_time*1e3:.3f} ms')\n",
+    "if hw_time > 0:\n",
+    "    print(f'Speedup (CPU/HW): {cpu_time/hw_time:.2f}x')\n"
    ]
   },
   {
@@ -139,7 +147,9 @@
    "source": [
     "# Compare results\n",
     "x_hw = np.array(a_x)\n",
-    "print('Results match:', np.allclose(x_ref, x_hw, atol=1e-6))"
+    "print('Results match:', np.allclose(x_ref, x_hw, atol=1e-6))\n",
+    "pretty_print('CPU result x_ref', x_ref)\n",
+    "pretty_print('Hardware result x_hw', x_hw)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Print tridiagonal solver input and results in a readable format.
- Show available overlay IP names and add CPU vs hardware timing comparison.

## Testing
- `python -m nbconvert --to notebook --execute thomas_solver_test/ThomasSolverTest.ipynb --output /tmp/out.ipynb` *(fails: No module named 'pynq')*

------
https://chatgpt.com/codex/tasks/task_e_68926c793a148332be9a4a799601e288