### PR TITLE
Add Pynq test for DiffractionOnly overlay

### DIFF
--- a/diffraction_only_test/README.md
+++ b/diffraction_only_test/README.md
@@ -1,0 +1,5 @@
+# Diffraction Only Overlay | Ejemplo
+
+Este directorio contiene los artefactos del componente **DiffractionOnly_v1**. Coloca aquí los archivos `DiffractionOnly_v1.bit` y `DiffractionOnly_v1.hwh` generados por Vivado/Vitis.
+
+El notebook `diffraction_only_test.ipynb` carga el overlay, envía datos de prueba, compara la salida con una implementación en software y mide los tiempos de ejecución de ambas versiones.

--- a/diffraction_only_test/diffraction_only_test.ipynb
+++ b/diffraction_only_test/diffraction_only_test.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiffractionOnly_v1 Overlay Test\n",
+    "\n",
+    "Este notebook carga el overlay `DiffractionOnly_v1` y compara la salida del kernel con una implementación en software.\n",
+    "Asegúrate de colocar `DiffractionOnly_v1.bit` y `DiffractionOnly_v1.hwh` en esta carpeta antes de ejecutar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pynq import Overlay, allocate\n",
+    "import numpy as np\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cargar overlay\n",
+    "ol = Overlay('DiffractionOnly_v1.bit')\n",
+    "\n",
+    "# Instancia del IP - cambia el nombre si es diferente\n",
+    "ip = ol.diffraction_only_v1_0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Implementación en software como referencia\n",
+    "def diffraction_sw(signal):\n",
+    "    kernel = np.array([0.25, 0.5, 0.25], dtype=np.float32)\n",
+    "    return np.convolve(signal, kernel, mode='same')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generar datos de prueba\n",
+    "N = 1024\n",
+    "in_data = np.random.rand(N).astype(np.float32)\n",
+    "\n",
+    "# Software\n",
+    "t0 = time.time()\n",
+    "sw_out = diffraction_sw(in_data)\n",
+    "sw_time = time.time() - t0\n",
+    "print(f'Software time: {sw_time*1e3:.2f} ms')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hardware\n",
+    "in_buffer = allocate(shape=(N,), dtype=np.float32)\n",
+    "out_buffer = allocate(shape=(N,), dtype=np.float32)\n",
+    "np.copyto(in_buffer, in_data)\n",
+    "\n",
+    "t0 = time.time()\n",
+    "# Escribe las direcciones de memoria; ajusta offsets si es necesario\n",
+    "ip.write(0x10, in_buffer.physical_address)\n",
+    "ip.write(0x18, out_buffer.physical_address)\n",
+    "ip.write(0x00, 1)  # ap_start\n",
+    "while (ip.read(0x00) & 0x2) == 0:\n",
+    "    pass\n",
+    "hw_time = time.time() - t0\n",
+    "hw_out = np.array(out_buffer)\n",
+    "print(f'Hardware time: {hw_time*1e3:.2f} ms')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validación\n",
+    "diff = np.abs(sw_out - hw_out)\n",
+    "print('Max error:', diff.max())\n",
+    "print('HW faster by {:.2f}x'.format(sw_time / hw_time))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add `diffraction_only_test` folder to host the DiffractionOnly_v1 bitstream and handoff
- Provide `diffraction_only_test.ipynb` showing how to load the overlay, validate results against a software model, and measure execution time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf72e80dc8332969296237a201c3f