### PR TITLE
Add copy kernel test notebook

### DIFF
--- a/copy_kernel_test/README.md
+++ b/copy_kernel_test/README.md
@@ -1,0 +1,5 @@
+# Copy Kernel Test
+
+Este ejemplo contiene un kernel muy simple que copia una matriz de números complejos de entrada a salida.
+Se incluye un cuaderno de Jupyter para generar una matriz con perfil gaussiano, enviarla al hardware y verificar
+que la salida coincida con la entrada.

--- a/copy_kernel_test/copy_kernel.cpp
+++ b/copy_kernel_test/copy_kernel.cpp
@@ -1,0 +1,14 @@
+#include "copy_kernel.h"
+
+extern "C" void copy_kernel(const complex_t* in, complex_t* out) {
+#pragma HLS INTERFACE s_axilite port=return bundle=control
+#pragma HLS INTERFACE m_axi port=in  bundle=gmem depth=4096
+#pragma HLS INTERFACE m_axi port=out bundle=gmem depth=4096
+#pragma HLS INTERFACE s_axilite port=in  bundle=control
+#pragma HLS INTERFACE s_axilite port=out bundle=control
+
+  for (int idx = 0; idx < TOTAL; ++idx) {
+#pragma HLS PIPELINE II=1
+    out[idx] = in[idx];
+  }
+}

--- a/copy_kernel_test/copy_kernel.h
+++ b/copy_kernel_test/copy_kernel.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <complex>
+#ifndef N
+#define N 64
+#endif
+static constexpr int TOTAL = N * N;
+using complex_t = std::complex<float>;
+extern "C" void copy_kernel(const complex_t* in, complex_t* out);

--- a/copy_kernel_test/copy_kernel_test.ipynb
+++ b/copy_kernel_test/copy_kernel_test.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a5820ee4",
+   "metadata": {},
+   "source": [
+    "# Copy Kernel Test\n",
+    "Este cuaderno prueba el kernel `copy_kernel` copiando una matriz de números complejos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b10c2af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pynq import Overlay, allocate\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5de35d19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ol = Overlay('sistema.bit')  # Reemplace con el bitstream que contiene copy_kernel\n",
+    "ip = ol.copy_kernel_0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be648e4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N = 64\n",
+    "TOTAL = N * N\n",
+    "x = np.linspace(-3, 3, N, dtype=np.float32)\n",
+    "X, Y = np.meshgrid(x, x)\n",
+    "sigma = 0.8\n",
+    "gaussian = np.exp(-(X**2 + Y**2) / (2 * sigma**2)).astype(np.float32)\n",
+    "in_matrix = gaussian.astype(np.complex64)\n",
+    "in_buffer = allocate(shape=(TOTAL,), dtype=np.complex64)\n",
+    "out_buffer = allocate(shape=(TOTAL,), dtype=np.complex64)\n",
+    "np.copyto(in_buffer, in_matrix.reshape(TOTAL))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fd007d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ip.write(0x10, in_buffer.physical_address)\n",
+    "ip.write(0x18, out_buffer.physical_address)\n",
+    "ip.write(0x00, 1)  # ap_start\n",
+    "while (ip.read(0x00) & 0x2) == 0:\n",
+    "    pass\n",
+    "out_matrix = np.array(out_buffer).reshape(N, N)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "253a99fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 4))\n",
+    "axes[0].imshow(np.abs(in_matrix))\n",
+    "axes[0].set_title('Entrada |in|')\n",
+    "axes[1].imshow(np.abs(out_matrix))\n",
+    "axes[1].set_title('Salida |out|')\n",
+    "diff = out_matrix - in_matrix\n",
+    "axes[2].imshow(np.abs(diff))\n",
+    "axes[2].set_title('|in - out|')\n",
+    "for ax in axes: ax.axis('off')\n",
+    "plt.show()\n",
+    "print('Error máximo:', np.max(np.abs(diff)))"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add copy kernel source and header defining a simple accelerator that copies complex arrays
- provide Jupyter notebook to generate a Gaussian complex matrix, invoke the copy kernel, and visualize input, output, and their difference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7b9b6f0c8332b204fd229391e1c7