### PR TITLE
Resolve data directory in diff_losses notebook

### DIFF
--- a/diff_losses_nsteps_test/diff_losses_nsteps_test.ipynb
+++ b/diff_losses_nsteps_test/diff_losses_nsteps_test.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "N = 64\n",
     "steps = 361\n",
-    "DATA_DIR = Path('diff_losses_nsteps_test')\n",
+    "DATA_DIR = Path(__file__).resolve().parent if '__file__' in globals() else Path.cwd()\n",
     "def read_matrix(fn):\n",
     "    data = np.loadtxt(fn, dtype=np.float32)\n",
     "    m = (data[:,0] + 1j*data[:,1]).astype(np.complex64)\n",


### PR DESCRIPTION
## Summary
- Resolve `DATA_DIR` in `diff_losses_nsteps_test.ipynb` using the notebook's directory instead of a hard-coded path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b22a5920148332839d55a6ae5bee6e