### PR TITLE
Add phase mask masking to diff losses notebook

### DIFF
--- a/diff_losses_nsteps_test/diff_losses_nsteps_test.ipynb
+++ b/diff_losses_nsteps_test/diff_losses_nsteps_test.ipynb
@@ -25,6 +25,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.ndimage import gaussian_filter\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
    "id": "999c9bdc",
    "metadata": {},
@@ -180,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# --- Ejecución en hardware ---\n",
+    "# --- Ejecuci\u00f3n en hardware ---\n",
     "ol = Overlay('full_propagation.bit')  # reemplace con ruta al bitstream\n",
     "ip = ol.diff_losses_0\n",
     "TOTAL = N * N\n",
@@ -237,10 +247,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6327ecd0-38d5-4c5e-b804-55b874f754a4",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Genera la m\u00e1scara de fase aleatoria\n",
+    "x = np.linspace(-Lx/2, Lx/2, N, endpoint=False)\n",
+    "y = np.linspace(-Ly/2, Ly/2, N, endpoint=False)\n",
+    "X, Y = np.meshgrid(x, y, indexing='ij')\n",
+    "dx = x[1] - x[0]\n",
+    "dy = y[1] - y[0]\n",
+    "desviacion_fase = 0.2\n",
+    "correlacion_m = 5\n",
+    "theta = np.random.normal(0, desviacion_fase, size=(N, N))\n",
+    "theta = gaussian_filter(theta, sigma=correlacion_m)\n",
+    "mask = np.exp(1j * theta)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phi_sw_masked = phi_sw * mask\n",
+    "phi_hw_masked = phi_hw * mask\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12,5))\n",
+    "plt.subplot(1,2,1); plt.imshow(np.abs(phi_sw_masked)**2, cmap='inferno'); plt.title('Beam final (SW) enmascarado')\n",
+    "plt.subplot(1,2,2); plt.imshow(np.abs(phi_hw_masked)**2, cmap='inferno'); plt.title('Beam final (HW) enmascarado')\n",
+    "plt.show()\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- add imports for gaussian filter and mask utilities
- generate a random phase mask and apply it to SW/HW results
- plot masked intensities for comparison

## Testing
- `pre-commit run --files diff_losses_nsteps_test/diff_losses_nsteps_test.ipynb` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b23710eff48332bf49285ce59480ea